### PR TITLE
rewind index when rewind into skip

### DIFF
--- a/intf/cnsr_intf.lua
+++ b/intf/cnsr_intf.lua
@@ -137,9 +137,13 @@ function looper()
 					actions[tag.action].execute(tag)
 				end
 				done = tag_index == #tags
-				if not done and current_time>tag.start_time then
-					tag_index = tag_index + 1
-					tag = tags[tag_index]
+				if not done then
+					if tag.action == SKIP then
+						tag = get_current_tag(tags, tags_by_end_time) --if we skipped back we need to rewind the index
+					else
+						tag_index = tag_index + 1
+						tag = tags[tag_index]
+					end
 				end
 			end
 			prev_time = current_time


### PR DESCRIPTION
fixed issue #58 by adding a call to get_current_index after a skip in order to rewind the index when necessary.