### PR TITLE
86 - Fix config file json encoding in Mac OS

### DIFF
--- a/extensions/cnsr_ext.lua
+++ b/extensions/cnsr_ext.lua
@@ -117,7 +117,6 @@ this function gets the uri of the movie and changes it to cnsr_uri
 --]]
 function get_cnsr_uri()
 	if vlc.input.item() == nil then
-		set_config(cfg, "CNSR")
 		return nil
 	end
 	local uri = vlc.input.item():uri()
@@ -196,7 +195,8 @@ function load_and_set_tags()
 		Log("description: " .. tostring(CATEGORIES[v.category].description))
 		Log("action: " .. tostring(options[v.action]))
 	end
-	set_config(cfg, "CNSR")
+	set_config(cfg.tags, "CNSR", 9)
+	set_config(cfg.tags_by_end_time, "CNSR", 10)
 end
 
 --[[ 
@@ -301,21 +301,28 @@ end
 this function gets configs in a file
 --]]
 function get_config()
-	config = json.decode(vlc.config.get("bookmark10") or "")
-	if config == nil then
-		config = {}
+	config.CNSR = {}
+
+	config.CNSR.tags = json.decode(vlc.config.get("bookmark9") or "")
+	config.CNSR.tags_by_end_time = json.decode(vlc.config.get("bookmark10") or "")
+
+	if config.CNSR.tags == nil then
+		config.CNSR.tags = {}
+	end
+
+	if config.CNSR.tags_by_end_time  == nil then
+		config.CNSR.tags_by_end_time  = {}
 	end
 end
 
 --[[ 
 this function saves configs in a file
 --]]
-function set_config(cfg_table, cfg_title)
+function set_config(cfg_table, cfg_title, bookmark_num)
 	if not cfg_table then cfg_table={} end
 	if not cfg_title then cfg_title=descriptor().title end
-	get_config()
 	config[cfg_title]=cfg_table
-	vlc.config.set("bookmark10", json.encode(config))
+	vlc.config.set("bookmark" .. tostring(bookmark_num), json.encode(cfg_table))
 end
 
 function SplitString(s, d) -- string, delimiter pattern

--- a/intf/cnsr_intf.lua
+++ b/intf/cnsr_intf.lua
@@ -148,8 +148,9 @@ function looper()
 	while true do
 		if vlc.volume.get() == -256 then break end  -- inspired by syncplay.lua; kills vlc.exe process in Task Manager
 		if loop_counter == 0 then
+			log("got config 0")
 			get_config() -- We don't want to call it more then we have to.
-			log("got config")
+			log("got config 1")
 		end
 		loop_counter = (loop_counter + 1) % GET_CONFIG_INTERVAL
 		if vlc.playlist.status()~="stopped" and config.CNSR and config.CNSR.tags then
@@ -268,10 +269,17 @@ end
 this function reads configs from a file and sets the config parameter
 --]]
 function get_config()
+	config.CNSR = {}
 
-	config = json.decode(vlc.config.get("bookmark10") or "")
-	if config == nil then
-		config = {}
+	config.CNSR.tags = json.decode(vlc.config.get("bookmark9") or "")
+	config.CNSR.tags_by_end_time = json.decode(vlc.config.get("bookmark10") or "")
+
+	if config.CNSR.tags == nil then
+		config.CNSR.tags = {}
+	end
+
+	if config.CNSR.tags_by_end_time  == nil then
+		config.CNSR.tags_by_end_time  = {}
 	end
 end
 


### PR DESCRIPTION
splitted the configuration file into tags and tags_by_end_time and saved them into 2 different bookmarks. Works on Mac OS. Removed unused logic.