### PR TITLE
#21 - create shared memory

### DIFF
--- a/extensions/cnsr_ext.lua
+++ b/extensions/cnsr_ext.lua
@@ -1,6 +1,7 @@
 --some globals:
 json = require ('dkjson')
 require ('common')
+Memory = require ('cnsr_memory')
 config={}
 cfg={}
 dropdowns = {}
@@ -195,8 +196,8 @@ function load_and_set_tags()
 		Log("description: " .. tostring(CATEGORIES[v.category].description))
 		Log("action: " .. tostring(options[v.action]))
 	end
-	set_config(cfg.tags, "CNSR", 9)
-	set_config(cfg.tags_by_end_time, "CNSR", 10)
+
+	set_config(cfg, "CNSR")
 end
 
 --[[ 
@@ -301,10 +302,15 @@ end
 this function gets configs in a file
 --]]
 function get_config()
-	config.CNSR = {}
+	config = json.decode(Memory.get_config_string())
 
-	config.CNSR.tags = json.decode(vlc.config.get("bookmark9") or "")
-	config.CNSR.tags_by_end_time = json.decode(vlc.config.get("bookmark10") or "")
+	if config == nil then -- todo write config to an external file for later loads/use bookmarkN as caching mechanizm
+		config = {}
+	end
+
+	if config.CNSR == nil then
+		config.CNSR = {}
+	end
 
 	if config.CNSR.tags == nil then
 		config.CNSR.tags = {}
@@ -318,11 +324,12 @@ end
 --[[ 
 this function saves configs in a file
 --]]
-function set_config(cfg_table, cfg_title, bookmark_num)
+function set_config(cfg_table, cfg_title)
 	if not cfg_table then cfg_table={} end
 	if not cfg_title then cfg_title=descriptor().title end
 	config[cfg_title]=cfg_table
-	vlc.config.set("bookmark" .. tostring(bookmark_num), json.encode(cfg_table))
+
+	Memory.set_config_string(json.encode(config))
 end
 
 function SplitString(s, d) -- string, delimiter pattern

--- a/modules/cnsr_memory.lua
+++ b/modules/cnsr_memory.lua
@@ -1,0 +1,41 @@
+-- This module acts as a shared memory between the ext and the intf modules
+
+require('common')
+json = require("dkjson")
+
+Memory = {}
+
+function Memory.set_config_string(config)
+    set_memory("config", config)
+    set_memory("written", true)
+end
+
+function Memory.get_config_string()
+    set_memory("written", false)
+    return get_memory("config") or ""
+end
+
+function Memory.get_written()
+    return get_memory("written")
+end
+
+function set_memory(key, val)
+    local value = get_memory(key)
+    if value == val then
+        return
+    end
+    if value == nil then
+        vlc.var.create(vlc.object.playlist(), key, val)
+        return
+    end
+
+    vlc.var.set(vlc.object.playlist(), key, val)
+
+    vlc.var.create(vlc.object.playlist(), key, val)
+end
+
+function get_memory(key)
+    return vlc.var.get(vlc.object.playlist(), key)
+end
+
+return Memory

--- a/modules/cnsr_memory.lua
+++ b/modules/cnsr_memory.lua
@@ -30,8 +30,6 @@ function set_memory(key, val)
     end
 
     vlc.var.set(vlc.object.playlist(), key, val)
-
-    vlc.var.create(vlc.object.playlist(), key, val)
 end
 
 function get_memory(key)


### PR DESCRIPTION
Added cnsr_memory.lua module - acts as a shared memory between the different modules. Consolidated and unified config objects